### PR TITLE
chore(deps): block TypeScript 7 major bump (Phase 65)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,13 @@ updates:
       # build. Re-evaluate once swagger-client ships a v5-compatible release.
       - dependency-name: "js-yaml"
         update-types: ["version-update:semver-major"]
+      # TypeScript 7 is the native Go rewrite ("Corsa"), shipped as a preview.
+      # It removes node/node10 module resolution (TS5108), lacks declaration
+      # emit (required by @farm/types and apps/api), and is rejected by
+      # ts-jest (peer <7) and typescript-eslint (peer <6.1.0). Revisit once
+      # the toolchain supports it. See Phase 65 in ROADMAP.md.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
 
   # GitHub Actions — keep action versions and SHA pins up to date
   - package-ecosystem: github-actions

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -95,13 +95,16 @@ All 59 phases are complete. Detailed per-story breakdowns have been moved to git
 | Phase 62: API Docs & DB Hygiene | 2 | 7 | `TODO` |
 | Phase 63: Security & Validation Hardening | 2 | 11 | `TODO` |
 | Phase 64: ESM Build & Import Modernization | 1 | 4 | `TODO` |
-| **Total** | **185** | **724** | |
+| Phase 65: Dependency Update Governance — TypeScript 7 Block | 1 | 3 | `DONE` |
+| **Total** | **186** | **727** | |
 
 ---
 
 ## Future
 
 Phases 60-64 cover NestJS best-practices remediation identified in the 2026-06-20 architecture audit. Phase 60 completed (ESLint strict mode, 2 stories). Phase 64 (ESM Build) extracted from deferred portions of Phase 60. [Design spec](docs/specs/2026-06-20-nestjs-best-practices-remediation-design.md). [Phase 61 plan](docs/superpowers/plans/2026-06-25-phase61-nestjs-code-quality.md). [Phase 62 plan](docs/superpowers/plans/2026-06-26-phase62-api-docs-db-hygiene.md).
+
+Phase 65 blocks the premature TypeScript 7 major bump (Dependabot #268). TS7 is the native Go rewrite ("Corsa") shipped as a preview: it removes `node`/`node10` module resolution (`TS5108`), does not support declaration emit (required by `@farm/types` and `apps/api`), and is rejected by `ts-jest` (peer `<7`) and `typescript-eslint` (peer `<6.1.0`). Blocked at the ecosystem level, not by our config. [Phase 65 plan](docs/superpowers/plans/2026-07-13-typescript-7-block.md).
 
 New phases should be added following the existing hierarchy and added to the Summary table above.
 


### PR DESCRIPTION
TypeScript 7 is the native Go rewrite ("Corsa") shipped as a preview, not a drop-in replacement. Confirmed blockers via CI logs + peer deps:

1. Removes node/node10 module resolution -> TS5108 (fails @farm/types compile in setup-monorepo, and apps/api tsconfig.build/scripts).
2. ts-jest@29.4.11 peer requires typescript >=4.3 <7.
3. typescript-eslint@8.63.0 peer requires typescript >=4.8.4 <6.1.0.
4. TS7 lacks declaration emit, required by @farm/types (declaration + declarationMap) and apps/api (declaration:true) -- hard block.

Ecosystem-level incompatibility, same class as the js-yaml v5 block. Added a Dependabot ignore rule for typescript major bumps and recorded the decision as Phase 65 in ROADMAP.md. Closes #268.