### PR TITLE
fix(release): sync package-lock.json during release-it version bump

### DIFF
--- a/apps/api/.release-it.json
+++ b/apps/api/.release-it.json
@@ -33,6 +33,7 @@
     "after:bump": [
       "npm run openapi:generate",
       "npm --prefix ../../apps/web version ${version} --no-git-tag-version --allow-same-version",
+      "npm install --package-lock-only --prefix ../..",
       "sed -i \"s/^appVersion: .*/appVersion: \\\"${version}\\\"/\" ../../deploy/helm/farm/Chart.yaml",
       "sed -i \"s/^version: .*/version: ${version}/\" ../../deploy/helm/farm/Chart.yaml",
       "sed -i \"s|ghcr.io/ops-talks/farm-api:[0-9][0-9A-Za-z.+-]*|ghcr.io/ops-talks/farm-api:${version}|g\" ../../deploy/helm/farm/Chart.yaml",
@@ -40,6 +41,6 @@
       "sed -i \"s/^appVersion: .*/appVersion: \\\"${version}\\\"/\" ../../deploy/helm/observability/Chart.yaml",
       "sed -i \"s/^version: .*/version: ${version}/\" ../../deploy/helm/observability/Chart.yaml"
     ],
-    "before:release": "git add ../../CHANGELOG.md ../../apps/web/package.json openapi.json ../../deploy/helm/farm/Chart.yaml ../../deploy/helm/observability/Chart.yaml"
+    "before:release": "git add ../../CHANGELOG.md ../../apps/web/package.json ../../package-lock.json openapi.json ../../deploy/helm/farm/Chart.yaml ../../deploy/helm/observability/Chart.yaml"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
     },
     "apps/api": {
       "name": "farm",
-      "version": "0.27.0",
+      "version": "0.27.1",
       "license": "AGPL-3.0",
       "dependencies": {
         "@aws-sdk/client-api-gateway": "^3.1085.0",
@@ -568,7 +568,7 @@
       }
     },
     "apps/web": {
-      "version": "0.27.0",
+      "version": "0.27.1",
       "dependencies": {
         "@base-ui/react": "^1.6.0",
         "@dagrejs/dagre": "^3.0.0",


### PR DESCRIPTION
Root cause (confirmed via git history across v0.26.1, v0.27.0, v0.27.1): the before:release hook in apps/api/.release-it.json does a selective git add that never included package-lock.json. release-it bumps the version field in package.json directly -- it never re-runs npm to sync the lockfile. As a result, the lockfile's apps/api/apps/web workspace 'version' fields have been stale in every release for at least the last 3 releases (0.25.28 while package.json said 0.26.1, then 0.27.0; 0.27.0 while package.json said 0.27.1). This went undetected until the 'Validate lockfile integrity' CI gate was added on 2026-07-09, two hours after the v0.27.0 release -- v0.27.1 was the first release to hit that gate.

Fix:
1. Added 'npm install --package-lock-only --prefix ../..' to the after:bump hooks, right after the apps/web version bump, so the lockfile's workspace version fields are resynced before anything is staged.
2. Added package-lock.json to the before:release git add list.
3. Synced the currently-stale package-lock.json now (v0.27.1 release): confirmed via diff that ONLY the two workspace 'version' fields changed (0.27.0 -> 0.27.1 for apps/api and apps/web) -- zero dependency changes. Verified idempotency (re-running npm install --package-lock-only produces no further diff).

Verified: npm run lint/test/build --workspace=apps/api all pass (262/262 suites, 3660/3660 tests).